### PR TITLE
Update q.py

### DIFF
--- a/q.py
+++ b/q.py
@@ -28,8 +28,18 @@ class QQoutput():
         elif (mode == 1):
             str = ''
             try:
+                j = 0
                 for i in range(0, len(data)):
-                    str += chr(ord(data[i]) ^ ord(self.key[i % len(self.key)]))
+                    # 获取unicode码
+                    unicode = ord(data[i])
+                    # 如果大于ffff 处理emoji
+                    if (unicode > 0xffff):
+                        # 分为2个10位二进制与两个密码进行异或
+                        code = ( ( (unicode>>10) ^ ord(self.key[i+j % len(self.key)]) ) <<10 ) + ( (unicode&0x3FF) ^ ord(self.key[i+j+1 % len(self.key)]) )
+                        str += chr(code)
+                        j = j + 1
+                    else:
+                        str += chr(ord(data[i]) ^ ord(self.key[i+j % len(self.key)]))
             except:
                 str = NULL
             return str

--- a/q.py
+++ b/q.py
@@ -35,7 +35,7 @@ class QQoutput():
                     # 如果大于ffff 处理emoji
                     if (unicode > 0xffff):
                         # 分为2个10位二进制与两个密码进行异或
-                        code = ( ( (unicode>>10) ^ ord(self.key[i+j % len(self.key)]) ) <<10 ) + ( (unicode&0x3FF) ^ ord(self.key[i+j+1 % len(self.key)]) )
+                        code = unicode ^ ((ord(self.key[i+j % len(self.key)])<<10) + ord(self.key[i+j+1 % len(self.key)]))
                         str += chr(code)
                         j = j + 1
                     else:


### PR DESCRIPTION
修复昵称中存在emoji的解密问题

## 分析如下：

原文昵称：🍁
unicode：\u1f341
二进制：0001 1111 0011 0100 0001

密码： 0x33 35
二进制：0011 0011 0011 0101

密文unicode：\u13f74
二进制：0001 0011 1111 0111 0100

比对可得
```
0001 0011 11   11 0111 0100    # 密文(\u13f74)
xor
0000 1100 11   00 0011 0101    # 密码(0x33和0x35)
(0x33)         (0x35)
=
0001 1111 00   11 0100 0001    # 原文(🍁)
```

即emoji的密文要从第10位分成两部分与密码进行异或，得到原文。
简要计算示例：

```python
dat = 0x13f74
key = [0x33, 0x35]

# 先计算前10位
dat>>10 ^ key[0] # 0x7c
# 再计算后10位
dat&0x3FF ^ key[1] # 0x341
# 两部分相加
(0x7c << 10) + 0x341 # 0x1f341

chr(0x1f341) # '🍁'
```